### PR TITLE
Add ignored_controleRequis

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -12,7 +12,8 @@ export declare enum LabelStatus {
     IGNORED_CODE_NAC_DECISION_PARTIELLEMENT_PUBLIQUE = "ignored_codeNACdeDecisionPartiellementPublique",
     IGNORED_CODE_NAC_INCONNU = "ignored_codeNACInconnu",
     IGNORED_CARACTERE_INCONNU = "ignored_caractereInconnu",
-    IGNORED_DATE_AVANT_MISE_EN_SERVICE = "ignored_dateAvantMiseEnService"
+    IGNORED_DATE_AVANT_MISE_EN_SERVICE = "ignored_dateAvantMiseEnService",
+    IGNORED_CONTROLE_REQUIS = "ignored_controleRequis"
 }
 /**
  * publishStatus:

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,6 +17,7 @@ var LabelStatus;
     LabelStatus["IGNORED_CODE_NAC_INCONNU"] = "ignored_codeNACInconnu";
     LabelStatus["IGNORED_CARACTERE_INCONNU"] = "ignored_caractereInconnu";
     LabelStatus["IGNORED_DATE_AVANT_MISE_EN_SERVICE"] = "ignored_dateAvantMiseEnService";
+    LabelStatus["IGNORED_CONTROLE_REQUIS"] = "ignored_controleRequis";
 })(LabelStatus || (exports.LabelStatus = LabelStatus = {}));
 /**
  * publishStatus:

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,8 @@ export enum LabelStatus {
   IGNORED_CODE_NAC_DECISION_PARTIELLEMENT_PUBLIQUE = 'ignored_codeNACdeDecisionPartiellementPublique',
   IGNORED_CODE_NAC_INCONNU = 'ignored_codeNACInconnu',
   IGNORED_CARACTERE_INCONNU = 'ignored_caractereInconnu',
-  IGNORED_DATE_AVANT_MISE_EN_SERVICE = 'ignored_dateAvantMiseEnService'
+  IGNORED_DATE_AVANT_MISE_EN_SERVICE = 'ignored_dateAvantMiseEnService',
+  IGNORED_CONTROLE_REQUIS = 'ignored_controleRequis'
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dbsder-api-types",
-  "version": "1.1.35",
+  "version": "1.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dbsder-api-types",
-      "version": "1.1.35",
+      "version": "1.1.37",
       "license": "MIT",
       "devDependencies": {
         "husky": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbsder-api-types",
-  "version": "1.1.35",
+  "version": "1.1.37",
   "description": "Librairie facilitant les interactions avec l'API DBSDER",
   "main": "dist/index.js",
   "author": "Cour de Cassation",


### PR DESCRIPTION
Ajout d'un `labelStatus` valant `ignored_controleRequis` en remplacement de l'envoi de la décision considérée dans Judifiltre.