### PR TITLE
Fix collapse undefined and null

### DIFF
--- a/src/typeGuards/decisions_tcom.zod.ts
+++ b/src/typeGuards/decisions_tcom.zod.ts
@@ -16,10 +16,10 @@ import {
 export const justiceFunctionTcomSchema = z.nativeEnum(JusticeFunctionTcom)
 
 const compositionTcomSchema = z.object({
-  fonction: justiceFunctionTcomSchema.optional(),
+  fonction: justiceFunctionTcomSchema.nullable().optional(),
   nom: z.string(),
-  prenom: z.string().optional(),
-  civilite: z.string().optional()
+  prenom: z.string().nullable().optional(),
+  civilite: z.string().nullable().optional()
 })
 
 export const justiceRoleTcomSchema = z.nativeEnum(JusticeRoleTcom)
@@ -28,8 +28,8 @@ const partieTcomSchema = z.object({
   type: zTypePartie,
   role: justiceRoleTcomSchema,
   nom: z.string(),
-  prenom: z.string().optional(),
-  civilite: z.string().optional()
+  prenom: z.string().nullable().optional(),
+  civilite: z.string().nullable().optional()
 })
 
 const objectIdSchema = z.any()
@@ -46,8 +46,8 @@ export const decisionTcomSchema = z.object({
   jurisdictionCode: z.string(),
   jurisdictionId: z.string(),
   jurisdictionName: z.string(),
-  public: z.boolean().optional(),
-  solution: z.string().optional(),
+  public: z.boolean().nullable().optional(),
+  solution: z.string().nullable().optional(),
   labelStatus: zLabelStatus,
   publishStatus: zPublishStatus.optional(),
   labelTreatments: z.array(zLabelTreatment).optional(),
@@ -59,21 +59,21 @@ export const decisionTcomSchema = z.object({
   zoning: z.record(z.unknown()).optional().nullable(),
   originalTextZoning: z.record(z.unknown()).optional(),
   pseudoTextZoning: z.record(z.unknown()).optional(),
-  chamberId: z.string().optional(),
-  chamberName: z.string().optional(),
+  chamberId: z.string().nullable().optional(),
+  chamberName: z.string().nullable().optional(),
   debatPublic: z.boolean(),
   selection: z.boolean(),
   blocOccultation: zBlocOccultation,
   occultation: zOccultation,
-  parties: z.array(partieTcomSchema).optional(),
+  parties: z.array(partieTcomSchema).nullable().optional(),
   filenameSource: z.string(),
   appeals: z.array(z.never()),
-  codeMatiereCivil: z.string().optional(),
+  codeMatiereCivil: z.string().nullable().optional(),
   idGroupement: z.string(),
   idDecisionTCOM: z.string(),
-  codeProcedure: z.string().optional(),
-  libelleMatiere: z.string().optional(),
-  composition: z.array(compositionTcomSchema).optional()
+  codeProcedure: z.string().nullable().optional(),
+  libelleMatiere: z.string().nullable().optional(),
+  composition: z.array(compositionTcomSchema).nullable().optional()
 })
 
 export function hasSourceNameTcom(x: UnIdentifiedDecision): x is UnIdentifiedDecisionTcom

--- a/src/typeGuards/decisions_tj.zod.ts
+++ b/src/typeGuards/decisions_tj.zod.ts
@@ -26,15 +26,15 @@ const decisionAssocieeTJSchema = z.object({
   numeroRegistre: z.string(),
   numeroRoleGeneral: z.string(),
   date: z.string(),
-  idDecisionWinci: z.string().optional()
+  idDecisionWinci: z.string().nullable().optional()
 })
 
 const partieTJSchema = z.object({
   type: zTypePartie,
   nom: z.string(),
-  prenom: z.string().optional(),
-  civilite: z.string().optional(),
-  qualite: zQualitePartie.optional()
+  prenom: z.string().nullable().optional(),
+  civilite: z.string().nullable().optional(),
+  qualite: zQualitePartie.nullable().optional()
 })
 
 export const decisionTjSchema = z.object({
@@ -47,27 +47,27 @@ export const decisionTjSchema = z.object({
   pseudoText: z.string().optional(),
   registerNumber: z.string(),
   dateDecision: z.string(),
-  jurisdictionCode: z.string().optional(),
+  jurisdictionCode: z.string().nullable().optional(),
   jurisdictionId: z.string(),
   jurisdictionName: z.string(),
-  public: z.boolean().optional(),
-  solution: z.string().optional(),
-  formation: z.string().optional(),
+  public: z.boolean().nullable().optional(),
+  solution: z.string().nullable().optional(),
+  formation: z.string().nullable().optional(),
   labelStatus: zLabelStatus,
   publishStatus: zPublishStatus.optional(),
   labelTreatments: z.array(zLabelTreatment).optional(),
   dateCreation: z.string(),
-  publishDate: z.string().optional().nullable(),
+  publishDate: z.string().optional(),
   firstImportDate: z.string().optional(),
   lastImportDate: z.string().optional(),
-  unpublishDate: z.string().optional().nullable(),
-  zoning: z.record(z.unknown()).optional().nullable(),
+  unpublishDate: z.string().optional(),
+  zoning: z.record(z.unknown()).nullable().optional(),
   originalTextZoning: z.record(z.unknown()).optional(),
   pseudoTextZoning: z.record(z.unknown()).optional(),
   NACCode: z.string(),
   libelleNAC: z.string(),
-  NPCode: z.string().optional(),
-  libelleNatureParticuliere: z.string().optional(),
+  NPCode: z.string().nullable().optional(),
+  libelleNatureParticuliere: z.string().nullable().optional(),
   endCaseCode: z.string(),
   libelleEndCaseCode: z.string(),
   chamberId: z.literal(''),
@@ -75,25 +75,25 @@ export const decisionTjSchema = z.object({
   codeService: z.string(),
   libelleService: z.string(),
   debatPublic: z.boolean(),
-  indicateurQPC: z.boolean().optional(),
+  indicateurQPC: z.boolean().nullable().optional(),
   matiereDeterminee: z.boolean(),
   pourvoiCourDeCassation: z.boolean(),
   pourvoiLocal: z.boolean(),
   selection: z.boolean(),
-  sommaire: z.string().optional(),
+  sommaire: z.string().nullable().optional(),
   blocOccultation: zBlocOccultation,
   recommandationOccultation: zSuiviOccultation,
   occultation: zOccultation,
-  president: presidentTJSchema.optional(),
-  parties: z.array(partieTJSchema).optional(),
+  president: presidentTJSchema.nullable().optional(),
+  parties: z.array(partieTJSchema).nullable().optional(),
   filenameSource: z.string(),
   idDecisionTJ: z.string(),
-  idDecisionWinci: z.string().optional(),
+  idDecisionWinci: z.string().nullable().optional(),
   numeroRoleGeneral: z.string(),
   appeals: z.array(z.string()),
   decatt: z.array(z.never()),
   publication: z.array(z.never()),
-  decisionAssociee: decisionAssocieeTJSchema.optional()
+  decisionAssociee: decisionAssocieeTJSchema.nullable().optional()
 })
 
 export function hasSourceNameTj(x: UnIdentifiedDecision): x is UnIdentifiedDecisionTj

--- a/src/types/decisions_tcom.ts
+++ b/src/types/decisions_tcom.ts
@@ -17,10 +17,10 @@ export enum JusticeFunctionTcom {
 }
 
 type CompositionTcom = {
-  fonction?: JusticeFunctionTcom
+  fonction?: JusticeFunctionTcom | null
   nom: string
-  prenom?: string
-  civilite?: string
+  prenom?: string | null
+  civilite?: string | null
 }
 
 export enum JusticeRoleTcom {
@@ -36,8 +36,8 @@ type PartieTcom = {
   type: TypePartie
   role: JusticeRoleTcom
   nom: string
-  prenom?: string
-  civilite?: string
+  prenom?: string | null
+  civilite?: string | null
 }
 
 export type DecisionTcom = {
@@ -57,8 +57,8 @@ export type DecisionTcom = {
   jurisdictionId: string
   jurisdictionName: string
 
-  public?: boolean
-  solution?: string
+  public?: boolean | null
+  solution?: string | null
 
   labelStatus: LabelStatus
   publishStatus?: PublishStatus
@@ -74,27 +74,27 @@ export type DecisionTcom = {
   originalTextZoning?: { [k: string]: unknown }
   pseudoTextZoning?: { [k: string]: unknown }
 
-  chamberId?: string
-  chamberName?: string
+  chamberId?: string | null
+  chamberName?: string | null
 
   debatPublic: boolean
   selection: boolean
 
   blocOccultation: BlocOccultation
   occultation: Occultation
-  parties?: PartieTcom[]
+  parties?: PartieTcom[] | null
 
   filenameSource: string
 
   appeals: never[]
 
-  codeMatiereCivil?: string
+  codeMatiereCivil?: string | null
 
   idGroupement: string
   idDecisionTCOM: string
-  codeProcedure?: string
-  libelleMatiere?: string
-  composition?: CompositionTcom[]
+  codeProcedure?: string | null
+  libelleMatiere?: string | null
+  composition?: CompositionTcom[] | null
 }
 
 export type UnIdentifiedDecisionTcom = Omit<DecisionTcom, '_id'>

--- a/src/types/decisions_tj.ts
+++ b/src/types/decisions_tj.ts
@@ -22,15 +22,15 @@ type DecisionAssocieeTj = {
   numeroRegistre: string
   numeroRoleGeneral: string
   date: string
-  idDecisionWinci?: string
+  idDecisionWinci?: string | null
 }
 
 type PartieTj = {
   type: TypePartie
   nom: string
-  prenom?: string
-  civilite?: string
-  qualite?: QualitePartie
+  prenom?: string | null
+  civilite?: string | null
+  qualite?: QualitePartie | null
 }
 
 export type DecisionTj = {
@@ -47,20 +47,20 @@ export type DecisionTj = {
   registerNumber: string
   dateDecision: string
 
-  jurisdictionCode?: string
+  jurisdictionCode?: string | null
   jurisdictionId: string
   jurisdictionName: string
 
-  public?: boolean
-  solution?: string
-  formation?: string
+  public?: boolean | null
+  solution?: string | null
+  formation?: string | null
 
   labelStatus: LabelStatus
   publishStatus?: PublishStatus
   labelTreatments?: LabelTreatment[]
 
   dateCreation: string
-  publishDate?: string | null
+  publishDate?: string
   firstImportDate?: string
   lastImportDate?: string
   unpublishDate?: string | null
@@ -72,8 +72,8 @@ export type DecisionTj = {
 
   NACCode: string
   libelleNAC: string
-  NPCode?: string
-  libelleNatureParticuliere?: string
+  NPCode?: string | null
+  libelleNatureParticuliere?: string | null
   endCaseCode: string
   libelleEndCaseCode: string
 
@@ -83,29 +83,29 @@ export type DecisionTj = {
   libelleService: string
 
   debatPublic: boolean
-  indicateurQPC?: boolean
+  indicateurQPC?: boolean | null
   matiereDeterminee: boolean
   pourvoiCourDeCassation: boolean
   pourvoiLocal: boolean
   selection: boolean
-  sommaire?: string
+  sommaire?: string | null
 
   blocOccultation: BlocOccultation
   recommandationOccultation: SuiviOccultation
   occultation: Occultation
 
-  president?: PresidentTj
-  parties?: PartieTj[]
+  president?: PresidentTj | null
+  parties?: PartieTj[] | null
 
   filenameSource: string
   idDecisionTJ: string
-  idDecisionWinci?: string
+  idDecisionWinci?: string | null
   numeroRoleGeneral: string
 
   appeals: string[]
   decatt: never[]
   publication: never[]
-  decisionAssociee?: DecisionAssocieeTj
+  decisionAssociee?: DecisionAssocieeTj | null
 }
 
 export type UnIdentifiedDecisionTj = Omit<DecisionTj, '_id'>


### PR DESCRIPTION
Juritj & juritcom collapse between null & undefined 
(typescript strict-null-check = false & class-validator isOptional)

For now and to be sure: properties undefined coming from collect have to be nullable. 