### PR TITLE
fix: objectId is string

### DIFF
--- a/src/typeGuards/codeNacs.zod.ts
+++ b/src/typeGuards/codeNacs.zod.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
-import { ObjectId } from 'bson'
 import {
   Category,
   zBlocOccultation,
   zDebatsPublics,
   zDecisionsPubliques,
-  zLabelRoute
+  zLabelRoute,
+  zObjectId
 } from './common.zod'
 
 const zCategory = z.enum(Category)
@@ -37,7 +37,7 @@ const categoriesToOmitSchema = z.object({
 })
 
 const CodeNacSchema = z.object({
-  _id: z.instanceof(ObjectId),
+  _id: zObjectId,
   codeNAC: z.string().length(3).nonoptional(),
   libelleNAC: z.string().nonoptional(),
   chapitre: ChapitreSchema.nonoptional(),

--- a/src/typeGuards/common.zod.ts
+++ b/src/typeGuards/common.zod.ts
@@ -242,6 +242,8 @@ export const zObjectId = z
     return ObjectId.isValid(id) && new ObjectId(id).toString() === id
   })
 
+export type DbsderId = z.infer<typeof zObjectId>
+
 export const zZoneRange = z.object({
   start: z.number(),
   end: z.number()

--- a/src/typeGuards/common.zod.ts
+++ b/src/typeGuards/common.zod.ts
@@ -241,7 +241,6 @@ export const zObjectId = z
   .refine((id: string) => {
     return ObjectId.isValid(id) && new ObjectId(id).toString() === id
   })
-  .transform((_) => new ObjectId(_))
 
 export const zZoneRange = z.object({
   start: z.number(),

--- a/src/typeGuards/index.ts
+++ b/src/typeGuards/index.ts
@@ -41,8 +41,7 @@ import {
   UnIdentifiedDecisionDila
 } from './decisions_dila.zod'
 
-import { zObjectId } from './common.zod'
-import { ObjectId } from 'bson'
+import { zObjectId, DbsderId } from './common.zod'
 import { ZodError } from 'zod'
 
 export {
@@ -115,7 +114,8 @@ export {
   LabelRoute,
   RaisonInteretParticulier,
   DecisionsPubliques,
-  DebatsPublics
+  DebatsPublics,
+  DbsderId
 } from './common.zod'
 export { parseAffaire, parsePartialAffaire, Affaire, UnIdentifiedAffaire } from './affaires.zod'
 export { CategorieCodeDecision, CodeDecision } from './codeDecisions.zod'
@@ -143,7 +143,7 @@ export type UnIdentifiedDecision =
   | UnIdentifiedDecisionDila
   | UnIdentifiedDecisionCph
 
-export function parseId(x: unknown): ObjectId {
+export function parseId(x: unknown): DbsderId {
   return zObjectId.parse(x)
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "nodenext",
     "target": "es2020",
     "outDir": "./dist",
     "rootDir": "src",
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Rappels sur la publication du package

Le package est publié automatiquement lorsqu'un tag est ajouté. Le tag doit respecter le format `[0-9]+.[0-9]+.[0-9]+`. Pour clarifier le suivi il est préconisé d'ajouter le tag via une release github une fois la branche mergée sur master.
